### PR TITLE
Revert "Fix muxListener to always close its channel of connections"

### DIFF
--- a/cmux.go
+++ b/cmux.go
@@ -99,7 +99,6 @@ func (m *cMux) Match(matchers ...Matcher) net.Listener {
 	ml := muxListener{
 		Listener: m.root,
 		connc:    make(chan net.Conn, m.bufLen),
-		closed:   new(sync.Once),
 	}
 	m.sls = append(m.sls, matchersListener{ss: matchers, l: ml})
 	return ml
@@ -113,7 +112,7 @@ func (m *cMux) Serve() error {
 		wg.Wait()
 
 		for _, sl := range m.sls {
-			_ = sl.l.Close()
+			close(sl.l.connc)
 			// Drain the connections enqueued for the listener.
 			for c := range sl.l.connc {
 				_ = c.Close()
@@ -178,15 +177,7 @@ func (m *cMux) handleErr(err error) bool {
 
 type muxListener struct {
 	net.Listener
-	connc  chan net.Conn
-	closed *sync.Once
-}
-
-func (l muxListener) Close() error {
-	l.closed.Do(func() {
-		close(l.connc)
-	})
-	return l.Listener.Close()
+	connc chan net.Conn
 }
 
 func (l muxListener) Accept() (net.Conn, error) {

--- a/cmux_test.go
+++ b/cmux_test.go
@@ -65,10 +65,6 @@ func newChanListener() *chanListener {
 	return &chanListener{connCh: make(chan net.Conn, 1)}
 }
 
-func (l *chanListener) Close() error {
-	return nil
-}
-
 func (l *chanListener) Accept() (net.Conn, error) {
 	if c, ok := <-l.connCh; ok {
 		return c, nil
@@ -419,22 +415,6 @@ func TestClose(t *testing.T) {
 		if _, err := c2.Read([]byte{}); err != io.ErrClosedPipe {
 			t.Fatalf("connection is not closed and is leaked: %v", err)
 		}
-	}
-}
-
-func TestCloseListenerWithoutServe(t *testing.T) {
-	defer leakCheck(t)()
-
-	l := newChanListener()
-	muxl := New(l)
-	anyl := muxl.Match(Any())
-
-	if err := anyl.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	if _, err := anyl.Accept(); err != ErrListenerClosed {
-		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
This reverts commit 310ba7a098bb9f690077d684cbffd6a7b88b6d20.

As discussed offline, we'll just live with the weird interface and work around it in cockroachdb rather than fixing it here (as in #8).